### PR TITLE
Overhaul test suite

### DIFF
--- a/src/proxy/ProxyDeoxys.sol
+++ b/src/proxy/ProxyDeoxys.sol
@@ -23,5 +23,9 @@ contract ProxyDeoxys is ERC1967Proxy {
 
     constructor(address _logic, bytes memory _data) ERC1967Proxy(_logic, _data) payable {}
 
+    function getImpl() external view returns (address impl) {
+        return _implementation();
+    }
+
     receive() external payable override {}
 }

--- a/test/ProxyDeoxys.t.sol
+++ b/test/ProxyDeoxys.t.sol
@@ -11,23 +11,10 @@ contract ProxyDeoxysTest is TestUtils {
     ProxyDeoxys public proxyDeoxys;
     WETH public proxysWETH;
 
-    uint256 mainnetFork;
-    string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
-
     string name;
     string symbol;
-    uint256 public priceInGweth;
-    uint256 public maxSupply;
-    uint256 public allocatedSupply;
     uint256 public typeMax;
     uint256 public _mintMax;
-    uint256 internal bidder1PrivateKey;
-    uint256 internal bidder2PrivateKey;
-    uint256 internal bidder3PrivateKey;
-    address internal bidder1;
-    address internal bidder2;
-    address internal bidder3;
-    bytes public err;
     bytes public data;
 
     // ERC721A transfer
@@ -35,8 +22,6 @@ contract ProxyDeoxysTest is TestUtils {
 
     // initialize test environment
     function setUp() public {
-        // mainnetFork = vm.createFork(MAINNET_RPC_URL);
-        // vm.selectFork(mainnetFork);
 
         typeMax = type(uint256).max;
         _mintMax = 30;

--- a/test/ProxyDeoxys.t.sol
+++ b/test/ProxyDeoxys.t.sol
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: AGPL
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "solmate/tokens/WETH.sol";
 import "../src/proxy/SettlementUUPS.sol";
-import "../src/Example721A.sol";
-import "../src/utils/BidSignatures.sol";
 import "../src/proxy/ProxyDeoxys.sol";
+import "./utils/TestUtils.sol";
 
-address payable constant mainnetWETH = payable(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-
-contract ProxyDeoxysTest is Test {
+contract ProxyDeoxysTest is TestUtils {
 
     SettlementUUPS public settlement;
     ProxyDeoxys public proxyDeoxys;
     WETH public proxysWETH;
-    Example721A public pikaExample;
 
     uint256 mainnetFork;
     string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
@@ -41,8 +35,8 @@ contract ProxyDeoxysTest is Test {
 
     // initialize test environment
     function setUp() public {
-        mainnetFork = vm.createFork(MAINNET_RPC_URL);
-        vm.selectFork(mainnetFork);
+        // mainnetFork = vm.createFork(MAINNET_RPC_URL);
+        // vm.selectFork(mainnetFork);
 
         typeMax = type(uint256).max;
         _mintMax = 30;
@@ -112,6 +106,3 @@ contract ProxyDeoxysTest is Test {
         address(proxyDeoxys).call(upgrade);
     }
 }
-// function to test implementation contract is set properly
-// function to test init can not be called again
-// function to prove storage layouts are equivalent

--- a/test/Settlement.t.sol
+++ b/test/Settlement.t.sol
@@ -102,15 +102,15 @@ function test_settle() public {
         this.finalizeAuction(signatures);
 
         // assert payments were processed correctly
-        assertEq(pikaExample.balanceOf(bidder1), bid1.amount);
-        assertEq(pikaExample.balanceOf(bidder2), bid2.amount);
+        assertEq(auctionA.balanceOf(bidder1), bid1.amount);
+        assertEq(auctionA.balanceOf(bidder2), bid2.amount);
         assertEq(weth.balanceOf(address(this)), 0);
         
         // assert owners of nfts are correct
         // ERC721A defaults to _startTokenId() == 0, causing _currentIndex to be 0
         // that is acceptable for this test, projects wishing to begin tokenIds at 1 should override that function
         for (uint i; i < bid1.amount + bid2.amount; ++i) {
-            address recipient = pikaExample.ownerOf(i);
+            address recipient = auctionA.ownerOf(i);
             if (i < bid1.amount) {
                 assertEq(recipient, bidder1);
             } else {
@@ -123,7 +123,7 @@ function test_settle() public {
         // create bid with 0 as amount
         BidSignatures.Bid memory bid0 = Bid({
             auctionName: "TestNFT",
-            auctionAddress: address(pikaExample),
+            auctionAddress: address(auctionA),
             bidder: bidder1,
             amount: 0,
             basePrice: auctionPriceA,
@@ -150,12 +150,12 @@ function test_settle() public {
         this.finalizeAuction(signatures);
 
         // check that no mints occurred without reverts
-        uint256 zero = pikaExample.totalSupply();
+        uint256 zero = auctionA.totalSupply();
         assertEq(zero, 0);
-        uint256 none = pikaExample.balanceOf(bid0.bidder);
+        uint256 none = auctionA.balanceOf(bid0.bidder);
         assertEq(none, 0);
         vm.expectRevert();
-        pikaExample.ownerOf(0);
+        auctionA.ownerOf(0);
     }
 
     function test_skipSingleInsufficientApproval() public {
@@ -179,7 +179,7 @@ function test_settle() public {
         // assert WETH transfer was not completed
         assertEq(weth.balanceOf(address(this)), 0);
         // assert NFT was not minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), 0);
+        assertEq(auctionA.balanceOf(bidder1), 0);
 
         // bid and finalize with nonzero but insufficient approval
         vm.prank(bidder2);
@@ -205,7 +205,7 @@ function test_settle() public {
         // assert WETH transfer was not completed
         assertEq(weth.balanceOf(address(this)), 0);
         // assert NFT was not minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), 0);
+        assertEq(auctionA.balanceOf(bidder1), 0);
     }
 
     function test_skipInsufficientApprovals() public {
@@ -269,19 +269,19 @@ function test_settle() public {
         this.finalizeAuction(signatures);
 
         // assert WETH transfers were completed by bidder1, bidder3
-        assertEq(address(pikaExample).balance, finalPayment);
+        assertEq(address(auctionA).balance, finalPayment);
         assertEq(weth.balanceOf(address(this)), 0);
 
         // assert NFTs were minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), bid1.amount);
+        assertEq(auctionA.balanceOf(bidder1), bid1.amount);
         // assert NFTs were NOT minted to bidder2
-        assertEq(pikaExample.balanceOf(bidder2), 0);
+        assertEq(auctionA.balanceOf(bidder2), 0);
         // assert NFTs were minted to bidder3
-        assertEq(pikaExample.balanceOf(bidder3), bid3.amount);
+        assertEq(auctionA.balanceOf(bidder3), bid3.amount);
 
         // assert correct NFT ownership
-        for (uint i; i < pikaExample.totalSupply(); ++i) {
-            address recipient = pikaExample.ownerOf(i);
+        for (uint i; i < auctionA.totalSupply(); ++i) {
+            address recipient = auctionA.ownerOf(i);
             if (i < bid1.amount) {
                 assertEq(recipient, bidder1);
             } else {
@@ -324,9 +324,9 @@ function test_settle() public {
         // assert WETH transfer was not completed due to insufficient balamnce
         assertEq(weth.balanceOf(address(this)), 0);
         // assert NFT was not minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), 0);
-        // assert pikaExample did not receive any eth
-        assertEq(address(pikaExample).balance, 0);
+        assertEq(auctionA.balanceOf(bidder1), 0);
+        // assert auctionA did not receive any eth
+        assertEq(address(auctionA).balance, 0);
     }
 
         // test skipping insufficient balances within multiple signatures
@@ -392,14 +392,14 @@ function test_settle() public {
             assertEq(weth.balanceOf(bidder1), 1 ether - (bid1.amount * bid1.basePrice + bid1.tip));
             assertEq(weth.balanceOf(bidder2), 1 ether - (bid2.amount * bid2.basePrice + bid2.tip));
             assertEq(weth.balanceOf(address(this)), 0);
-            assertEq(address(pikaExample).balance, finalPayment);
+            assertEq(address(auctionA).balance, finalPayment);
 
             // assert NFTs were minted to bidder1, bidder3
-            assertEq(pikaExample.balanceOf(bidder1), bid1.amount);
-            assertEq(pikaExample.balanceOf(bidder2), bid2.amount);
+            assertEq(auctionA.balanceOf(bidder1), bid1.amount);
+            assertEq(auctionA.balanceOf(bidder2), bid2.amount);
 
             // assert NFT was not minted to bidder3
-            assertEq(pikaExample.balanceOf(bidder3), 0);
+            assertEq(auctionA.balanceOf(bidder3), 0);
     }
 
     function test_skipSpentSigNonces() public {
@@ -446,9 +446,9 @@ function test_settle() public {
         emit SettlementFailure(signature1.bid.bidder, "Payment Failed");
         this.finalizeAuction(signature);
         // assert payment was not completed
-        assertEq(address(pikaExample).balance, 0);
+        assertEq(address(auctionA).balance, 0);
         // assert NFT was not minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), 0);
+        assertEq(auctionA.balanceOf(bidder1), 0);
         // assert signature was marked spent
         bytes32 sigHash = 
             keccak256(
@@ -482,12 +482,12 @@ function test_settle() public {
         this.finalizeAuction(signatures);
 
         // assert payment completed only for signature2 and signature3
-        assertEq(address(pikaExample).balance, finalPayment);
+        assertEq(address(auctionA).balance, finalPayment);
         // assert NFT was not minted to bidder1
-        assertEq(pikaExample.balanceOf(bidder1), 0);
+        assertEq(auctionA.balanceOf(bidder1), 0);
         // assert NFTs were minted to bidder2 and bidder3
-        assertEq(pikaExample.balanceOf(bidder2), bid2.amount);
-        assertEq(pikaExample.balanceOf(bidder3), bid3.amount);
+        assertEq(auctionA.balanceOf(bidder2), bid2.amount);
+        assertEq(auctionA.balanceOf(bidder3), bid3.amount);
         // assert signature still marked spent
         bool stillSpent = spentSigNonces[sigHash];
         assertTrue(stillSpent);
@@ -497,7 +497,7 @@ function test_settle() public {
     function test_settleUncheckedCannotOverflow() public {
         Bid memory overflowBid = Bid({
             auctionName: "TestNFT",
-            auctionAddress: address(pikaExample),
+            auctionAddress: address(auctionA),
             bidder: bidder1,
             amount: 30,
             basePrice: type(uint256).max,
@@ -637,9 +637,28 @@ function test_settle() public {
 
         // assert only the first bid successfully minted as the second exceeded maxSupply
         uint256 amountToMint = allocatedMinus10.amount + justRight.amount;
-        assertEq(pikaExample.totalSupply(), amountToMint);
-        assertEq(pikaExample.balanceOf(bidder1), allocatedMinus10.amount);
-        assertEq(pikaExample.balanceOf(bidder2), 0); // overflow failure
-        assertEq(pikaExample.balanceOf(bidder3), justRight.amount);
+        assertEq(auctionA.totalSupply(), amountToMint);
+        assertEq(auctionA.balanceOf(bidder1), allocatedMinus10.amount);
+        assertEq(auctionA.balanceOf(bidder2), 0); // overflow failure
+        assertEq(auctionA.balanceOf(bidder3), justRight.amount);
+    }
+
+    // ensure Settlement contract is capable of handling multiple ongoing auctions at once
+    function test_multipleOngoingAuctions() public {
+        // users sign bids to submit for auction A
+        (uint8 v1a, bytes32 r1a, bytes32 s1a) = _prepareAndSignDigest(bid1, bidder1PrivateKey);
+        Signature memory sig1a = _generateSig(bid1, v1a, r1a, s1a);
+        (uint8 v2a, bytes32 r2a, bytes32 s2a) = _prepareAndSignDigest(bid2, bidder2PrivateKey);
+        Signature memory sig2a = _generateSig(bid2, v2a, r2a, s2a);
+        (uint8 v3a, bytes32 r3a, bytes32 s3a) = _prepareAndSignDigest(bid3, bidder3PrivateKey);
+        Signature memory sig3a = _generateSig(bid3, v3a, r3a, s3a);
+        // users sign bids to submit for auction B
+
+        // users sign bids to submit for auction C
+
+        // initialize signature arrays for multiple ongoing auction settlement
+        Signature[] memory auctionOneSigs = new Signature[](3);
+        Signature[] memory auctionTwoSigs = new Signature[](3);
+        Signature[] memory auctionThreeSigs = new Signature[](3);
     }
 }

--- a/test/Settlement.t.sol
+++ b/test/Settlement.t.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: AGPL
 pragma solidity ^0.8.13;
 
-import "forge-std/Test.sol";
-import "solmate/tokens/WETH.sol";
+// import "forge-std/Test.sol";
 import "./utils/TestUtils.sol";
 
 contract SettlementTest is TestUtils { 
 
-    // initialize test environment
-    function setUp() public {
-        
-    }
-
+    // ensure test environment was properly initialized by TestUtils constructor
     function test_setUp() public {
         assertEq(vm.activeFork(), mainnetFork);
         assertEq(weth.balanceOf(bidder1), 1 ether);

--- a/test/Settlement.t.sol
+++ b/test/Settlement.t.sol
@@ -642,23 +642,4 @@ function test_settle() public {
         assertEq(auctionA.balanceOf(bidder2), 0); // overflow failure
         assertEq(auctionA.balanceOf(bidder3), justRight.amount);
     }
-
-    // ensure Settlement contract is capable of handling multiple ongoing auctions at once
-    function test_multipleOngoingAuctions() public {
-        // users sign bids to submit for auction A
-        (uint8 v1a, bytes32 r1a, bytes32 s1a) = _prepareAndSignDigest(bid1, bidder1PrivateKey);
-        Signature memory sig1a = _generateSig(bid1, v1a, r1a, s1a);
-        (uint8 v2a, bytes32 r2a, bytes32 s2a) = _prepareAndSignDigest(bid2, bidder2PrivateKey);
-        Signature memory sig2a = _generateSig(bid2, v2a, r2a, s2a);
-        (uint8 v3a, bytes32 r3a, bytes32 s3a) = _prepareAndSignDigest(bid3, bidder3PrivateKey);
-        Signature memory sig3a = _generateSig(bid3, v3a, r3a, s3a);
-        // users sign bids to submit for auction B
-
-        // users sign bids to submit for auction C
-
-        // initialize signature arrays for multiple ongoing auction settlement
-        Signature[] memory auctionOneSigs = new Signature[](3);
-        Signature[] memory auctionTwoSigs = new Signature[](3);
-        Signature[] memory auctionThreeSigs = new Signature[](3);
-    }
 }

--- a/test/Settlement.t.sol
+++ b/test/Settlement.t.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL
 pragma solidity ^0.8.13;
 
-// import "forge-std/Test.sol";
 import "./utils/TestUtils.sol";
 
 contract SettlementTest is TestUtils { 
 
-    // ensure test environment was properly initialized by TestUtils constructor
+    // ensure test environment was properly initialized
     function test_setUp() public {
         assertEq(vm.activeFork(), mainnetFork);
         assertEq(weth.balanceOf(bidder1), 1 ether);
@@ -14,7 +13,7 @@ contract SettlementTest is TestUtils {
         assertEq(weth.balanceOf(bidder3), 1 ether);
     }
 
-function test_settle() public {
+    function test_settle() public {
         // calculate totalWeth to pay
         uint256 totalWeth = bid1.amount * bid1.basePrice + bid1.tip;
         // bidder1 approves totalWeth amount to weth contract

--- a/test/SettlementUUPS.t.sol
+++ b/test/SettlementUUPS.t.sol
@@ -754,6 +754,24 @@ function test_settle() public {
     }
 
     /// @dev Internal helper functions to alleviate the occurrance of the dreaded 'sTaCk tOo DeEp' error
+    function _generateBid(
+        string memory _auctionName,
+        address _auctionAddress,
+        address _bidder,
+        uint256 _amount,
+        uint256 _basePrice,
+        uint256 _tip
+    ) internal pure returns (BidSignatures.Bid memory) {
+        return (BidSignatures.Bid({
+            auctionName: _auctionName,
+            auctionAddress: _auctionAddress,
+            bidder: _bidder,
+            amount: _amount,
+            basePrice: _basePrice,
+            tip: _tip
+        }));
+    }
+    
     function _prepareAndSignDigest(Bid memory _bid, uint256 _privateKey) internal view returns (uint8 _v, bytes32 _r, bytes32 _s) {
             // prepare digest
             bytes32 digest = settlement.hashTypedData(_bid);

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -11,7 +11,7 @@ address payable constant mainnetWETH = payable(0xC02aaA39b223FE8D0A0e5C4F27eAD90
 
 abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
 
-    Example721A public pikaExample;
+    Example721A public auctionA;
     Example721A public auctionB;
     Example721A public auctionC;
 
@@ -63,8 +63,8 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
         allocatedSupplyC = 150;
 
         // zero address used as placeholder for revenue recipient
-        pikaExample = _generateAuction(
-            "PikaExample", 
+        auctionA = _generateAuction(
+            "auctionA", 
             "PIKA", 
             address(this), 
             address(0x0), 
@@ -120,7 +120,7 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
         // prepare bids
         bid1 = _generateBid(
             "TestNFT",
-            address(pikaExample),
+            address(auctionA),
             bidder1,
             30,
             auctionPriceA,
@@ -129,7 +129,7 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
 
         bid2 = _generateBid(
             "TestNFT",
-            address(pikaExample),
+            address(auctionA),
             bidder2,
             42,
             auctionPriceA,
@@ -138,7 +138,7 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
 
         bid3 = _generateBid(
             "TestNFT",
-            address(pikaExample),
+            address(auctionA),
             bidder3,
             12,
             auctionPriceA,
@@ -147,8 +147,8 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
 
         // bids for test_allocatedSupply
         allocatedMinus10 = _generateBid(
-            "PikaExample",
-            address(pikaExample),
+            "auctionA",
+            address(auctionA),
             bidder1,
             allocatedSupplyA - 10,
             auctionPriceA,
@@ -156,8 +156,8 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
         );
 
         overFlow = _generateBid(
-            "PikaExample",
-            address(pikaExample),
+            "auctionA",
+            address(auctionA),
             bidder2,
             11, // set to result in overflow, allocatedMints += amount > allocatedSupply
             auctionPriceA,
@@ -165,8 +165,8 @@ abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
         );
 
         justRight = _generateBid(
-            "PikaExample",
-            address(pikaExample),
+            "auctionA",
+            address(auctionA),
             bidder3,
             10,
             auctionPriceA,

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "solmate/tokens/WETH.sol";
+import "../../src/Settlement.sol";
+import "../../src/Example721A.sol";
+import "../../src/utils/BidSignatures.sol";
+
+address payable constant mainnetWETH = payable(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+abstract contract TestUtils is Test, Settlement(mainnetWETH, 200) {
+
+    Example721A public pikaExample;
+    Example721A public auctionB;
+    Example721A public auctionC;
+
+    uint256 mainnetFork;
+    string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
+
+    string name;
+    string symbol;
+    uint256 public auctionPriceA;
+    uint256 public auctionPriceB;
+    uint256 public auctionPriceC;
+    uint256 public maxSupplyA;
+    uint256 public maxSupplyB;
+    uint256 public maxSupplyC;
+    uint256 public allocatedSupplyA;
+    uint256 public allocatedSupplyB;
+    uint256 public allocatedSupplyC;
+    uint256 internal bidder1PrivateKey;
+    uint256 internal bidder2PrivateKey;
+    uint256 internal bidder3PrivateKey;
+    address internal bidder1;
+    address internal bidder2;
+    address internal bidder3;
+    BidSignatures.Bid bid1;
+    BidSignatures.Bid bid2;
+    BidSignatures.Bid bid3;
+    BidSignatures.Bid allocatedMinus10;
+    BidSignatures.Bid overFlow;
+    BidSignatures.Bid justRight;
+    bytes public err;
+
+    // ERC721A transfer
+    event Transfer(address indexed from, address indexed to, uint256 indexed id);
+
+    // initialize test environment
+    constructor() {
+        mainnetFork = vm.createFork(MAINNET_RPC_URL);
+        vm.selectFork(mainnetFork);
+
+        // utilize various values including free mints as well as partial and entire Pikapool allocations
+        auctionPriceA = 69;
+        auctionPriceB = 10;
+        auctionPriceC = 0;
+        maxSupplyA = type(uint256).max;
+        maxSupplyB = 100;
+        maxSupplyC = 150;
+        allocatedSupplyA = 100;
+        allocatedSupplyB = 50;
+        allocatedSupplyC = 150;
+
+        // zero address used as placeholder for revenue recipient
+        pikaExample = _generateAuction(
+            "PikaExample", 
+            "PIKA", 
+            address(this), 
+            address(0x0), 
+            auctionPriceA,
+            type(uint256).max,
+            allocatedSupplyA
+        );
+
+        auctionB = _generateAuction(
+            'AuctionB', 
+            'B', 
+            address(this), 
+            address(0x0), 
+            auctionPriceB,
+            maxSupplyB,
+            allocatedSupplyB
+        );
+
+        auctionC = _generateAuction(
+            'AuctionC', 
+            'C', 
+            address(this), 
+            address(0x0), 
+            auctionPriceC,
+            maxSupplyC,
+            allocatedSupplyC
+        );
+
+        // prepare the cow carcass private key with which to sign
+        bidder1PrivateKey = 0xDEADBEEF;
+        bidder1 = vm.addr(bidder1PrivateKey);
+        // seed cow carcass bidder1 with 1 eth and wrap it to weth
+        vm.deal(bidder1, 1 ether);
+        vm.prank(bidder1);
+        weth.deposit{ value: 1 ether }();
+
+        // create new beefy bidder for second signature
+        bidder2PrivateKey = 0xBEEF;
+        bidder2 = vm.addr(bidder2PrivateKey);
+        // seed cow bidder with 1 eth and wrap it to weth
+        vm.deal(bidder2, 1 ether);
+        vm.prank(bidder2);
+        weth.deposit{ value: 1 ether }();
+
+        // create new beefy bidder for third signature
+        bidder3PrivateKey = 0xBABE;
+        bidder3 = vm.addr(bidder3PrivateKey);
+        // seed cow bidder with 1 eth and wrap it to weth
+        vm.deal(bidder3, 1 ether);
+        vm.prank(bidder3);
+        weth.deposit{ value: 1 ether }();
+
+        // prepare bids
+        bid1 = _generateBid(
+            "TestNFT",
+            address(pikaExample),
+            bidder1,
+            30,
+            auctionPriceA,
+            69
+        );
+
+        bid2 = _generateBid(
+            "TestNFT",
+            address(pikaExample),
+            bidder2,
+            42,
+            auctionPriceA,
+            42
+        );
+
+        bid3 = _generateBid(
+            "TestNFT",
+            address(pikaExample),
+            bidder3,
+            12,
+            auctionPriceA,
+            420
+        );
+
+        // bids for test_allocatedSupply
+        allocatedMinus10 = _generateBid(
+            "PikaExample",
+            address(pikaExample),
+            bidder1,
+            allocatedSupplyA - 10,
+            auctionPriceA,
+            0
+        );
+
+        overFlow = _generateBid(
+            "PikaExample",
+            address(pikaExample),
+            bidder2,
+            11, // set to result in overflow, allocatedMints += amount > allocatedSupply
+            auctionPriceA,
+            1
+        );
+
+        justRight = _generateBid(
+            "PikaExample",
+            address(pikaExample),
+            bidder3,
+            10,
+            auctionPriceA,
+            2
+        );
+    }
+
+    /// @dev Internal helper functions to alleviate the occurrance of the dreaded 'sTaCk tOo DeEp' error
+    function _generateAuction(
+        string memory _name,
+        string memory _symbol,
+        address _settlementContract,
+        address _recipient,
+        uint256 _priceInWei,
+        uint256 _maxSupply,
+        uint256 _allocatedSupply
+    ) internal returns (Example721A) {
+        return (new Example721A(
+            _name, 
+            _symbol, 
+            _settlementContract, 
+            _recipient, 
+            _priceInWei,
+            _maxSupply,
+            _allocatedSupply
+        ));
+    }
+
+    function _generateBid(
+        string memory _auctionName,
+        address _auctionAddress,
+        address _bidder,
+        uint256 _amount,
+        uint256 _basePrice,
+        uint256 _tip
+    ) internal pure returns (BidSignatures.Bid memory) {
+        return (BidSignatures.Bid({
+            auctionName: _auctionName,
+            auctionAddress: _auctionAddress,
+            bidder: _bidder,
+            amount: _amount,
+            basePrice: _basePrice,
+            tip: _tip
+        }));
+    }
+
+    function _generateSig(
+        BidSignatures.Bid memory _bid,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) internal pure returns (Signature memory) {
+        return (Signature({
+            bid: _bid,
+            v: _v,
+            r: _r,
+            s: _s
+        }));
+    }
+
+    function _prepareAndSignDigest(Bid memory _bid, uint256 _privateKey) internal view returns (uint8 _v, bytes32 _r, bytes32 _s) {
+            // prepare digest
+            bytes32 digest = hashTypedData(_bid);
+            (_v, _r, _s) = vm.sign(_privateKey, digest);
+        }
+
+    function _calculateTotal(Signature memory _sig) internal pure returns (uint256) {
+        return _sig.bid.amount * _sig.bid.basePrice + _sig.bid.tip;
+    }
+}


### PR DESCRIPTION
Refactored all tests to utilize the TestUtils.sol module which exports live auctions and bids for users to sign and for the settlement contract to asynchronously mint with.

TestUtils also provides the ability to regenerate auctions with a provided address parameter which is necessary in the case of a proxy. In the proxy structure's case, the settlementUUPS logic implementation is no longer serving the minter role as it does with a standalone contract, rather the ProxyDeoxys 1967 proxy is the one serving the minter role. Bids are regenerated simultaneously to update their target Pikapatible auctions.

TL;DR:
This PR makes the Settlement, SettlementUUPS, and ProxyDeoxys test files more compact + readable via code reuse, as well as allows the bids/auctions generated in TestUtils.sol to be used and regenerated on a whim by all tests across the entire repo.